### PR TITLE
Apple comment 3: TLS BR 4.10.1 — Revocation entry retention

### DIFF
--- a/OWGTMCPS.md
+++ b/OWGTMCPS.md
@@ -883,6 +883,8 @@ Certificate Status Services are accessible through HTTP servers owned by the OWG
 
 The appropriate certificate revocation information service URLs are included in standard extensions within the issued certificates.
 
+In accordance with Section 4.10.1 of the CA/Browser Forum TLS Baseline Requirements, revocation entries on a CRL or OCSP response are not removed until after the Expiry Date of the revoked Certificate.
+
 ### 4.10.2 Service availability
 
 The Certificate Status Services are available on a 24x7 basis.


### PR DESCRIPTION
## Summary

Addresses **Apple comment 3** (feedback of 18-Aug-2026) against Section 4.10.1 (Operational characteristics).

**Feedback received:** the section described where and how revocation information is accessed, but did not commit to the retention rule the Baseline Requirements impose.

## Change

Section 4.10.1 now states that revocation entries on a CRL or OCSP response are not removed until after the Expiry Date of the revoked Certificate.

All pre-existing stipulations are retained unchanged.

## Requirement references

- CA/Browser Forum TLS Baseline Requirements, Section 4.10.1 (Operational characteristics)
